### PR TITLE
Remove toolbarbutton.type (blank defaults to default button.)

### DIFF
--- a/src/content/overlay.xul
+++ b/src/content/overlay.xul
@@ -53,7 +53,6 @@
       class="toolbarbutton-1 chromeclass-toolbar-additional"
       label="RequestPolicy"
       tooltiptext="RequestPolicy"
-      type="menu-button"
       popup="rp-popup" />
   </toolbarpalette>
     <!-- oncontextmenu="event.preventDefault();" -->


### PR DESCRIPTION
"menu-button" is used for the new bookmark menu and needs another button beside it to complete the borders.

See
https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Attribute/toolbarbutton.type

Fixes
https://github.com/RequestPolicyContinued/requestpolicy/issues/462
