### PR TITLE
Do not put placeholders for blacklisted images

### DIFF
--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -673,7 +673,7 @@ requestpolicy.overlay = {
     for (var destBase in rejectedRequests) {
       for (var destIdent in rejectedRequests[destBase]) {
         for (var destUri in rejectedRequests[destBase][destIdent]) {
-          var shouldPlacehold = false; // = pref(show placeholder for blacklisted images)
+          var shouldPlacehold = this._rpService.prefs.getBoolPref("indicateBlacklistedObjects");
           var results = rejectedRequests[destBase][destIdent][destUri];
           for(var i=0; i < results.length && !shouldPlacehold; i++)
             shouldPlacehold = results[i].isDefaultPolicyUsed(); // if a request is blocked not by the default policy it's by a blacklist

--- a/src/content/settings/basicprefs.html
+++ b/src/content/settings/basicprefs.html
@@ -47,6 +47,12 @@
               </div>
               <div>
                 <label>
+                  <input type="checkbox" id="pref-indicateBlacklistedObjects"/>
+                  <span data-string="indicateBlacklistedImages"></span>
+                </label>
+              </div>
+              <div>
+                <label>
                   <input type="checkbox" id="pref-autoReload"/>
                   <span data-string="autoReload"></span>
                 </label>

--- a/src/content/settings/basicprefs.js
+++ b/src/content/settings/basicprefs.js
@@ -3,6 +3,7 @@ PAGE_STRINGS = [
   'advanced',
   'webPages',
   'indicateBlockedImages',
+  'indicateBlacklistedImages',
   'autoReload',
   'menu',
   'allowAddingNonTemporaryRulesInPBM'
@@ -18,6 +19,9 @@ var prefsChangedObserver = null;
 function updateDisplay() {
   document.getElementById('pref-indicateBlockedObjects').checked =
       rpService.prefs.getBoolPref('indicateBlockedObjects');
+
+  document.getElementById('pref-indicateBlacklistedObjects').checked =
+      rpService.prefs.getBoolPref('indicateBlacklistedObjects');
 
   document.getElementById('pref-autoReload').checked =
       rpService.prefs.getBoolPref('autoReload');
@@ -40,6 +44,13 @@ function onload() {
   document.getElementById('pref-indicateBlockedObjects').addEventListener('change',
       function (event) {
         rpService.prefs.setBoolPref('indicateBlockedObjects', event.target.checked);
+        rpService._prefService.savePrefFile(null);
+      }
+  );
+
+  document.getElementById('pref-indicateBlacklistedObjects').addEventListener('change',
+      function (event) {
+        rpService.prefs.setBoolPref('indicateBlacklistedObjects', event.target.checked);
         rpService._prefService.savePrefFile(null);
       }
   );

--- a/src/defaults/preferences/defaults.js
+++ b/src/defaults/preferences/defaults.js
@@ -13,6 +13,7 @@ pref("extensions.requestpolicy.defaultPolicy.allowSameDomain", true);
 pref("extensions.requestpolicy.welcomeWindowShown", false);
 
 pref("extensions.requestpolicy.indicateBlockedObjects", true);
+pref("extensions.requestpolicy.indicateBlacklistedObjects", true);
 pref("extensions.requestpolicy.startWithAllowAllEnabled", false);
 pref("extensions.requestpolicy.privateBrowsingPermanentWhitelisting", false);
 

--- a/src/locale/en-US/requestpolicy.properties
+++ b/src/locale/en-US/requestpolicy.properties
@@ -39,6 +39,7 @@ help=Help
 basic=Basic
 advanced=Advanced
 indicateBlockedImages=Indicate blocked images
+indicateBlacklistedImages=Indicate blocked by blacklist images
 autoReload=Reload current page when whitelist is changed
 webPages=Web Pages
 menu=Menu

--- a/src/locale/fr/requestpolicy.properties
+++ b/src/locale/fr/requestpolicy.properties
@@ -39,6 +39,7 @@ help=Help
 basic=Basic
 advanced=Avancé
 indicateBlockedImages=Indiquer les images bloquées
+indicateBlacklistedImages=Indiquer les images bloquées par blacklist
 autoReload=Actualiser la page en cours lorsque liste blanche est modifiée
 webPages=Pages Web
 menu=Menu


### PR DESCRIPTION
Controlled by the preference indicateBlacklistedObjects default true. When true it behaves as before with placeholders for all images (if indicateBlockedObjects is also true).
When false images which were blocked due to a blacklist get no placeholders.
