### PR TITLE
Enable/fix matching "*" as the destination

### DIFF
--- a/src/content/lib/ruleset.jsm
+++ b/src/content/lib/ruleset.jsm
@@ -869,7 +869,11 @@ Ruleset.prototype = {
     } else {
       var parts = host.split(".");
       var curLevel = this._domain;
-      var nextLevel;
+      // Start by checking for a wildcard at the highest level.
+      var nextLevel = curLevel.getLowerLevel("*");
+      if (nextLevel) {
+        yield nextLevel;
+      }
       for (var i = parts.length - 1; i >= 0; i--) {
         nextLevel = curLevel.getLowerLevel(parts[i]);
         if (!nextLevel) {


### PR DESCRIPTION
Using wildcards in the destination only appeared to work below the TLD level e.g. *.com.

If the default setting is allow then the user can deny a destination of "*" for a specific site to block all requests. A whitelist for that site can then be created by adding specific allow rules. This avoids having to use a default setting of deny and creating a whitelist for every single website.
