### PR TITLE
Enable/fix matching "*" as the destination

### DIFF
--- a/src/content/lib/request-processor.jsm
+++ b/src/content/lib/request-processor.jsm
@@ -985,7 +985,11 @@ RequestProcessor.prototype.checkRedirect = function(request) {
 
   var result = this._rpService._policyMgr.checkRequestAgainstUserRules(
       originURIObj, destURIObj);
-  // For now, we always give priority to deny rules.
+  // For user rules, use the default policy if both types of rule match.
+  if (result.denyRulesExist() && result.allowRulesExist()) {
+    result.isAllowed = this._rpService._defaultAllow;
+    return result;
+  }
   if (result.denyRulesExist()) {
     result.isAllowed = false;
     return result;

--- a/src/content/lib/ruleset.jsm
+++ b/src/content/lib/ruleset.jsm
@@ -869,7 +869,11 @@ Ruleset.prototype = {
     } else {
       var parts = host.split(".");
       var curLevel = this._domain;
-      var nextLevel;
+      // Start by checking for a wildcard at the highest level.
+      var nextLevel = curLevel.getLowerLevel("*");
+      if (nextLevel) {
+        yield nextLevel;
+      }
       for (var i = parts.length - 1; i >= 0; i--) {
         nextLevel = curLevel.getLowerLevel(parts[i]);
         if (!nextLevel) {

--- a/src/content/lib/ruleset.jsm
+++ b/src/content/lib/ruleset.jsm
@@ -915,22 +915,6 @@ Ruleset.prototype = {
           //dprint("DENY origin by rule " + entry + " " + rule);
           matchedDenyRules.push(["origin", entry, rule]);
         }
-        // switch(rule.originRuleAction) {
-        //   case RULE_ACTION_ALLOW:
-        //     if (ruleMatchedOrigin) {
-        //       dprint("ALLOW origin by rule " + entry + " " + rule);
-        //       matchedAllowRules.push(["origin", entry, rule]);
-        //     }
-        //     break;
-        //   case RULE_ACTION_DENY:
-        //     if (ruleMatchedOrigin) {
-        //               dprint("DENY origin by rule " + entry + " " + rule);
-        //               matchedDenyRules.push(["origin", entry, rule]);
-        //               //break originouterloop;
-        //               break;
-        //             }
-        //             break;
-        // }
         // Check if there are origin-to-destination rules from the origin host
         // entry we're currently looking at.
         if (ruleMatchedOrigin && rule.destinations) {
@@ -947,23 +931,6 @@ Ruleset.prototype = {
                 //dprint("DENY origin-to-dest by rule origin " + entry + " " + rule + " to dest " + destEntry + " " + destRule);
                 matchedDenyRules.push(["origin-to-dest", entry, rule, destEntry, destRule]);
               }
-
-              // switch(destRule.destinationRuleAction) {
-              //   case RULE_ACTION_ALLOW:
-              //     if (destRule.isMatch(dest)) {
-              //                     dprint("ALLOW origin-to-dest by rule origin " + entry + " " + rule + " to dest " + destEntry + " " + destRule);
-              //                     matchedAllowRules.push(["origin-to-dest", entry, rule, destEntry, destRule]);
-              //                   }
-              //     break;
-              //   case RULE_ACTION_DENY:
-              //     if (destRule.isMatch(dest)) {
-              //                     dprint("DENY origin-to-dest by rule origin " + entry + " " + rule + " to dest " + destEntry + " " + destRule);
-              //                     matchedDenyRules.push(["origin-to-dest", entry, rule, destEntry, destRule]);
-              //                     //break originouterloop;
-              //                     break;
-              //                   }
-              //                   break;
-              // }
             }
           }
           //dprint("Done checking origin-to-destination rules using this origin rule.");

--- a/src/content/lib/ruleset.jsm
+++ b/src/content/lib/ruleset.jsm
@@ -902,7 +902,7 @@ Ruleset.prototype = {
     }
     //dprint("Checking origin rules and origin-to-destination rules.");
     // First, check for rules for each part of the origin host.
-    originouterloop: for (var entry in this.getHostMatches(originHost)) {
+    for (var entry in this.getHostMatches(originHost)) {
       //dprint(entry);
       for (var rule in entry.rules) {
         //dprint("Checking rule: " + rule);
@@ -940,7 +940,7 @@ Ruleset.prototype = {
 
     //dprint("Checking dest rules.");
     // Last, check for rules for each part of the destination host.
-    destouterloop: for (var entry in this.getHostMatches(destHost)) {
+    for (var entry in this.getHostMatches(destHost)) {
       //dprint(entry);
       for (var rule in entry.rules) {
         //dprint("Checking rule: " + rule);
@@ -952,22 +952,6 @@ Ruleset.prototype = {
           //dprint("DENY dest by rule " + entry + " " + rule);
           matchedDenyRules.push(["dest", entry, rule]);
         }
-        // switch(rule.destinationRuleAction) {
-        //   case RULE_ACTION_ALLOW:
-        //     if (rule.isMatch(dest)) {
-        //               dprint("ALLOW dest by rule " + entry + " " + rule);
-        //               matchedAllowRules.push(["dest", entry, rule]);
-        //             }
-        //     break;
-        //   case RULE_ACTION_DENY:
-        //     if (rule.isMatch(dest)) {
-        //       dprint("DENY dest by rule " + entry + " " + rule);
-        //       matchedDenyRules.push(["dest", entry, rule]);
-        //       //break destouterloop;
-        //       break;
-        //     }
-        //     break;
-        // }
       }
     }
 


### PR DESCRIPTION
Using wildcards in the destination only appeared to work below the TLD level e.g. *.com.

If the default setting is allow then the user can now deny a destination of "*" for a specific site to block all requests. A whitelist for that site can then be created by adding specific allow rules. This avoids having to use a default setting of deny and creating a whitelist for every single website.

One issue was that RequestPolicy prioritises deny rules if the request is a redirect so I've addressed that by using the default policy type if both allow and deny user rules match a redirect, the same as with normal requests.