### PR TITLE
Check for explicit existence of lower level in domain hierarchy

### DIFF
--- a/src/content/lib/ruleset.jsm
+++ b/src/content/lib/ruleset.jsm
@@ -678,14 +678,16 @@ DomainEntry.prototype = {
   },
 
   addLowerLevel : function(name, entry) {
-    if (this._lower[name]) {
+    if (this._lower.hasOwnProperty(name)) {
       throw "ENTRY_ALREADY_EXISTS";
     }
     this._lower[name] = entry;
   },
 
   getLowerLevel : function(name) {
-    return this._lower[name];
+    if (this._lower.hasOwnProperty(name)) {
+      return this._lower[name];
+    }
   }
 };
 


### PR DESCRIPTION
Mozilla's implementation of `Object.prototype` has a predefined "watch" function which is retrieved via bracket notation even if not explicitly defined. This causes issues when parsing any domain with "watch" as part of its hierarchy, as `_lower['watch']` will unexpectedly return a function.