### PR TITLE
Updating makexpi.sh, firefox.dev.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 
 /tests/mozmill/data
 /tests/mozmill/mozmill-tests
+
+/firefox/

--- a/firefox.dev.sh
+++ b/firefox.dev.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # firefox_date=`date +%FT%H.%M`
 mkdir -p firefox/dev
-firefox -no-remote -profile ./firefox/dev $1 > './firefox/Mozilla Firefox.dev.log' 2>&1 &
+firefox -no-remote -profile ./firefox/dev $* > './firefox/Mozilla Firefox.dev.log' 2>&1 &

--- a/firefox.dev.sh
+++ b/firefox.dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# firefox_date=`date +%FT%H.%M`
+mkdir -p firefox/dev
+firefox -no-remote -profile ./firefox/dev $1 > './firefox/Mozilla Firefox.dev.log' 2>&1 &

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -20,14 +20,16 @@ version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ print $1 + 1 }'
 # redirect make.sh output (optional)
 # exec > $dist/$appdate-$APP-$version.log 2>&1
 
+## make $src/manifest.json unique => "version": "2.0.42"
+# INFO: This is recommended, to write into 'src/manifest.json': Going to make real new unique "version", each time.
+#sed -i 's/\.[0-9]*"/\.'$version'"/' $src/manifest.json
+# make "install.rdf" em:version unique
+# INFO: This is recommended, to write into 'src/install.rdf': Going to make real new unique <em:version>, each time.
+sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $src/install.rdf
+
 # copy $src/* to $build/
 cp --dereference -pr $src/* $build/
 cp --dereference -p README.md $build/README.md
-
-## make $src/manifest.json unique => "version": "2.0.42"
-#sed -i 's/\.[0-9]*"/\.'$version'"/' $src/manifest.json
-# make "install.rdf" em:version unique
-sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $build/install.rdf
 
 # preprocess (optional)
 echo "JavaScript .jsm" > $build/preprocess.txt
@@ -43,5 +45,5 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 XPI="$APP-$version~pre.xpi"
 rm -f $dist/$XPI
 (cd $build && zip -pr $dist/$XPI * )
-echo 'Created XPI '$XPI'.'
+echo 'D'$appdate' '$dir'/makexpi.sh: Created '$XPI'.'
 

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -42,5 +42,6 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 # make a zip, or xpi
 XPI="$APP-$version~pre.xpi"
 rm -f $dist/$XPI
-cd $build && zip -pr $dist/$XPI *
+(cd $build && zip -pr $dist/$XPI * )
+echo 'Created XPI '$XPI'.'
 

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -13,7 +13,7 @@ mkdir -p $build
 dist=$dir
 
 # get unique "install.rdf" em:version
-version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ sum = $1 } END { print sum + 1 }'`
+version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ print $1 + 1 }'`
 
 # redirect make.sh output (optional)
 # exec > $dist/$appdate-$APP-$version.log 2>&1
@@ -32,6 +32,7 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 		preprocess --content-types-path $build/preprocess.txt $src/$f > $build/$f
 #		preprocess --content-types-path $build/preprocess.txt -D LOG_ENVIRONMENT $src/$f > $build/$f
 	done
+	rm -f preprocess.txt
 )
 
 # make a zip, or xpi

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -36,5 +36,6 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 
 # make a zip, or xpi
 XPI="$APP-$version~pre.xpi"
+rm -f $dist/$XPI
 cd $build && zip -pr $dist/$XPI *
 

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Public Domain.
+dir=`pwd`
+APP=RequestPolicy
+appdate=`date +%FT%H.%M`
+
+src=$dir/src
+
+build=$dir/build
+rm -rf $build
+mkdir -p $build
+
+dist=$dir
+
+# make "install.rdf" em:version unique 
+version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ sum = $1 } END { print sum + 1 }'`
+XPI="$APP-$version~pre.xpi"
+if [ "$1" ]; then
+	version=$1
+	XPI="$XPI.xpi"
+fi
+sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $src/install.rdf
+
+# redirect make.sh output (optional)
+# exec > $dist/$appdate-$APP-$version.log 2>&1
+
+# copy $src/* to $build/
+cp --dereference -pr $src/* $build/
+cp --dereference -p README.md $build/README.md
+
+# preprocess (optional)
+echo "JavaScript .jsm" > $build/preprocess.txt
+( cd $build
+	for f in `find . -iname '*.jsm'` ; do
+		preprocess --content-types-path $build/preprocess.txt $src/$f > $build/$f
+	done
+)
+
+# make a zip, or xpi
+cd $build && zip -pr $dist/$XPI *
+

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -12,6 +12,8 @@ mkdir -p $build
 
 dist=$dir
 
+## get unique manifest.json (for example "version": "2.0.41" => "version": "2.0.42"),
+#version=`grep -P '"version": "([0-9]+\.)?' src/manifest.json |  grep -oP '[0-9]+"' | awk '{ print $1 + 1 }'`
 # get unique "install.rdf" em:version
 version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ print $1 + 1 }'`
 
@@ -22,6 +24,8 @@ version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ print $1 + 1 }'
 cp --dereference -pr $src/* $build/
 cp --dereference -p README.md $build/README.md
 
+## make $src/manifest.json unique => "version": "2.0.42"
+#sed -i 's/\.[0-9]*"/\.'$version'"/' $src/manifest.json
 # make "install.rdf" em:version unique
 sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $build/install.rdf
 

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -14,14 +14,9 @@ dist=$dir
 
 # make "install.rdf" em:version unique 
 version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ sum = $1 } END { print sum + 1 }'`
-XPI="$APP-$version"
-if [ "$1" ]; then
-	version=$1
-	XPI="$XPI.xpi"
-else
-	XPI="$XPI~pre.xpi"
-fi
 sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $src/install.rdf
+
+XPI="$APP-$version~pre.xpi"
 
 # redirect make.sh output (optional)
 # exec > $dist/$appdate-$APP-$version.log 2>&1

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -42,7 +42,7 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 )
 
 # make a zip, or xpi
-XPI="$APP-$version~pre.xpi"
+XPI="$APP~pre.xpi"
 rm -f $dist/$XPI
 (cd $build && zip -pr $dist/$XPI * )
 echo 'D'$appdate' '$dir'/makexpi.sh: Created '$XPI'.'

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -12,11 +12,8 @@ mkdir -p $build
 
 dist=$dir
 
-# make "install.rdf" em:version unique 
+# get unique "install.rdf" em:version
 version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ sum = $1 } END { print sum + 1 }'`
-sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $src/install.rdf
-
-XPI="$APP-$version~pre.xpi"
 
 # redirect make.sh output (optional)
 # exec > $dist/$appdate-$APP-$version.log 2>&1
@@ -24,6 +21,9 @@ XPI="$APP-$version~pre.xpi"
 # copy $src/* to $build/
 cp --dereference -pr $src/* $build/
 cp --dereference -p README.md $build/README.md
+
+# make "install.rdf" em:version unique
+sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $build/install.rdf
 
 # preprocess (optional)
 echo "JavaScript .jsm" > $build/preprocess.txt
@@ -35,5 +35,6 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 )
 
 # make a zip, or xpi
+XPI="$APP-$version~pre.xpi"
 cd $build && zip -pr $dist/$XPI *
 

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -14,10 +14,12 @@ dist=$dir
 
 # make "install.rdf" em:version unique 
 version=`grep -o '[0-9]*</em:version>' $src/install.rdf | awk '{ sum = $1 } END { print sum + 1 }'`
-XPI="$APP-$version~pre.xpi"
+XPI="$APP-$version"
 if [ "$1" ]; then
 	version=$1
 	XPI="$XPI.xpi"
+else
+	XPI="$XPI~pre.xpi"
 fi
 sed -i 's/[0-9]*<\/em:version>/'$version'<\/em:version>/' $src/install.rdf
 
@@ -33,6 +35,7 @@ echo "JavaScript .jsm" > $build/preprocess.txt
 ( cd $build
 	for f in `find . -iname '*.jsm'` ; do
 		preprocess --content-types-path $build/preprocess.txt $src/$f > $build/$f
+#		preprocess --content-types-path $build/preprocess.txt -D LOG_ENVIRONMENT $src/$f > $build/$f
 	done
 )
 


### PR DESCRIPTION
I want to suggest you a new `makexpi.sh` and a `firefox.dev.sh`.

The `makexpi.sh` is creating the AddOn, by adding 1 to `install.rdf` `em:version`, and running `preprocess`.

The `firefox.dev.sh` is running `firefox`, with `no-remote` and using a profile in `firefox/dev`.
If you run this the first time, a folder `./firefox/dev` is created; you have to go to `about:config` and set `xpinstall.signatures.required` to `false`, and `extensions.getAddons.cache.enabled` to `false`.

Now you go to `about:addons` and use drag'n'drop to install the AddOn.
You do this on every change. (You also may delete the folder `./firefox/dev` sometimes.)
If you want to do this on the command line, you may do `./firefox.dev.sh RequestPolicy-7~pre.xpi`.

Then you may want to see what the browser console says, you just need to open `Menu > Developer > Browser Console`.