### PR TITLE
Fixes Issue #865 : WE transition: Implement "fake" `browser.runtime.getURL()` function

### DIFF
--- a/src/conditional/legacy/content/web-extension-fake-api/models/api.js
+++ b/src/conditional/legacy/content/web-extension-fake-api/models/api.js
@@ -248,8 +248,8 @@ export const ContentScriptsApi = {
 
   /**
    * Map a relative path to manifest.json to a legacy path (XUL/XPCOM).
-   * All paths pointing to a html file in /content/settings/ are mapped into about:requestpolicy?,
-   * other paths are mapped into chrome://rpcontinued/ :
+   * All paths pointing to a html file in /content/settings/ are mapped into
+   * about:requestpolicy?, other paths are mapped into chrome://rpcontinued/ :
    *  - /content/settings/filename.html will become about:requestpolicy?filename
    *  - /foo/bar.file.css will become chrome://rpcontinued/foo/bar.file.css
    * Leading / or ./ are ignored and the path is case sensitive.
@@ -258,20 +258,23 @@ export const ContentScriptsApi = {
    * @return {string}
    */
   Api.browser.runtime.getURL = function(path) {
-
     // Pattern to match mapping into about:requestpolicy?file
-    // 1) ^(?:\.\/|\/)? : matches even if path starts with "content/" or "./content"
+    // 1) ^(?:\.\/|\/)? : matches even if path starts with "content/"
+    // or "./content"
     // 2) content\/settings\/ : checks path (case sensitive)
-    // 3) ([^\/]+) : capturing group for the filename (everything not containing /)
+    // 3) ([^\/]+) : capturing group for the filename
     // 4) \.[hH][tT][mM][lL]$ : matches html extension (case insensitive)
-    let patternAbout = /^(?:\.\/|\/)?content\/settings\/([^\/]+)\.[hH][tT][mM][lL]$/mg;
+    // Disable max-length line lint on this one because using new RegExp
+    // to split it isn't recommended if the pattern doesn't change
+    // eslint-disable-next-line max-len
+    let patternAbout = /^(?:\.\/|\/)?content\/settings\/([^/]+)\.[hH][tT][mM][lL]$/mg;
 
     // Pattern to match prepending with chrome://rpcontinued/
     // 1) ^(?:\.\/|\/)? : non capturing group for leading "/" or "./"
     let patternChrome = /^(?:\.\/|\/)?(.+)$/mg;
 
     let legacyPath = null;
-    
+
     if (patternAbout.test(path)) {
       legacyPath = path.replace(patternAbout, "about:requestpolicy?$1");
     } else {

--- a/tests/unit/lib/mock-components.js
+++ b/tests/unit/lib/mock-components.js
@@ -1,0 +1,29 @@
+// Some mocks for /gre/modules/Components.jsm
+// Warning : those mock must be only used for unit testing purpose
+// Warning : Those mocks are partial, add functions if needed
+
+// =============================================================================
+// Partial mock of Components.utils XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils
+// =============================================================================
+function Utils() {};
+Utils.prototype.import = function(mod) {};
+
+// =============================================================================
+// Partial mock of Components.interfaces XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.interfaces
+// =============================================================================
+function Interfaces() {
+  this.nsIPrefBranch2 = null;
+};
+
+// =============================================================================
+// Partial mock of Components XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components_object
+// =============================================================================
+function Components() {
+  this.utils = new Utils();
+  this.interfaces = new Interfaces();
+}
+
+module.exports = Components;

--- a/tests/unit/lib/mock-netutil.js
+++ b/tests/unit/lib/mock-netutil.js
@@ -1,7 +1,6 @@
 // Some mocks for /gre/modules/NetUtil.jsm
 // Warning : those mock must be only used for unit testing purpose
-// Those are partial mocks to successly load
-// src/conditional/legacy/content/web-extension-fake-api/models/api.js
+// Warning : Those mocks are partial, add functions if needed
 
 // =============================================================================
 // Partial mock of nsIInputStream XPCOM Class
@@ -42,7 +41,7 @@ NetUtil.prototype.newChannel = function(uriObj) {
 };
 
 NetUtil.prototype.readInputStreamToString = function(inputStream, count, charset) {
-  return "{\"permissions\" : []}";
+  return "";
 };
 
 module.exports = NetUtil;

--- a/tests/unit/lib/mock-netutil.js
+++ b/tests/unit/lib/mock-netutil.js
@@ -1,0 +1,48 @@
+// Some mocks for /gre/modules/NetUtil.jsm
+// Warning : those mock must be only used for unit testing purpose
+// Those are partial mocks to successly load
+// src/conditional/legacy/content/web-extension-fake-api/models/api.js
+
+// =============================================================================
+// Partial mock of nsIInputStream XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIChannel
+// =============================================================================
+
+function nsIInputStream() {};
+
+nsIInputStream.prototype.available = function() {
+  return 0;
+};
+
+nsIInputStream.prototype.close = function() {};
+
+// =============================================================================
+// Partial mock of nsIChannel XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIChannel
+// =============================================================================
+function nsIChannel() {};
+
+nsIChannel.prototype.open = function() {
+  return new nsIInputStream();
+};
+
+// =============================================================================
+// Partial mock of NetUtil.jsm
+// See : https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/NetUtil.jsm
+// =============================================================================
+
+function NetUtil() {};
+
+NetUtil.prototype.newURI = function(uri, charset) {
+  return "";
+};
+
+NetUtil.prototype.newChannel = function(uriObj) {
+  return new nsIChannel();
+};
+
+NetUtil.prototype.readInputStreamToString = function(inputStream, count, charset) {
+  return "{\"permissions\" : []}";
+};
+
+module.exports = NetUtil;

--- a/tests/unit/lib/mock-services.js
+++ b/tests/unit/lib/mock-services.js
@@ -1,7 +1,6 @@
 // Some mocks for /gre/modules/Services.jsm
 // Warning : those mock must be only used for unit testing purpose
-// Those are partial mocks to successly load
-// src/conditional/legacy/content/web-extension-fake-api/models/api.js
+// Warning : Those mocks are partial, add functions if needed
 
 // =============================================================================
 // Partial mock of nsIPrefBranch XPCOM Class

--- a/tests/unit/lib/mock-services.js
+++ b/tests/unit/lib/mock-services.js
@@ -1,0 +1,38 @@
+// Some mocks for /gre/modules/Services.jsm
+// Warning : those mock must be only used for unit testing purpose
+// Those are partial mocks to successly load
+// src/conditional/legacy/content/web-extension-fake-api/models/api.js
+
+// =============================================================================
+// Partial mock of nsIPrefBranch XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefBranch
+// =============================================================================
+
+function nsIPrefBranch() {};
+
+nsIPrefBranch.prototype.QueryInterface = function() {
+  return null;
+};
+
+// =============================================================================
+// Partial mock of nsIPrefService XPCOM Class
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefService
+// =============================================================================
+function nsIPrefService() {};
+
+nsIPrefService.prototype.getBranch = function(aPrefRoot) {
+  return new nsIPrefBranch();
+};
+
+nsIPrefService.prototype.savePrefFile = function(aFile) {};
+
+// =============================================================================
+// Partial mock of Services.jsm
+// See : https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Services.jsm
+// =============================================================================
+
+function Services() {
+  this.prefs = new nsIPrefService();
+};
+
+module.exports = Services;

--- a/tests/unit/test-webextension-fake-api.js
+++ b/tests/unit/test-webextension-fake-api.js
@@ -1,0 +1,28 @@
+var {assert} = require("chai");
+var sinon = require("sinon");
+
+var mockNetUtil = require("./lib/mock-netutil");
+var mockServices = require("./lib/mock-services");
+
+var Cu = {
+  import: function(p) {
+    return {
+      NetUtil : new mockNetUtil(),
+      AddonManager: {}
+    }
+  }
+};
+
+global.Cu = Cu;
+global.Services = new mockServices();
+//global.Ci = {nsIPrefBranch2: null}
+
+var {Api, ContentScriptsApi} = require("content/web-extension-fake-api/models/api");
+
+describe("Api.browser.runtime", function() {
+  describe("getUrl()", function() {
+    it("", function() {
+      //assert.strictEqual(Api.browser.runtime.getUrl("hey"), "hey");
+    });
+  });
+});

--- a/tests/unit/test-webextension-fake-api.js
+++ b/tests/unit/test-webextension-fake-api.js
@@ -1,28 +1,50 @@
 var {assert} = require("chai");
 var sinon = require("sinon");
 
-var mockNetUtil = require("./lib/mock-netutil");
-var mockServices = require("./lib/mock-services");
+// Loads mocking classes
+// Those mocks are needed because some scripts loads XPCOM objects like :
+// const {NetUtil} = Cu.import("resource://gre/modules/NetUtil.jsm");
+var MockNetUtil = require("./lib/mock-netutil");
+var MockServices = require("./lib/mock-services");
+var MockComponents = require("./lib/mock-components");
 
-var Cu = {
-  import: function(p) {
-    return {
-      NetUtil : new mockNetUtil(),
-      AddonManager: {}
-    }
-  }
-};
-
-global.Cu = Cu;
-global.Services = new mockServices();
-//global.Ci = {nsIPrefBranch2: null}
-
-var {Api, ContentScriptsApi} = require("content/web-extension-fake-api/models/api");
 
 describe("Api.browser.runtime", function() {
-  describe("getUrl()", function() {
-    it("", function() {
-      //assert.strictEqual(Api.browser.runtime.getUrl("hey"), "hey");
+
+  let runtime = null;
+
+  before(function() {
+    let mockComp = new MockComponents();
+    let mockNu = new MockNetUtil();
+
+    // Stubbing in order to return a Manifest object with empty permissions
+    // Needed because of manifestHasPermission() in api.js
+    sinon.stub(mockNu, "readInputStreamToString")
+      .returns('{"permissions" : []}');
+
+    // Stubbing in order to perform imports in api.js and required scripts
+    sinon.stub(mockComp.utils, "import")
+      .withArgs("resource://gre/modules/NetUtil.jsm").returns({NetUtil: mockNu})
+      .withArgs("resource://gre/modules/AddonManager.jsm", {}).returns({});
+
+    // Replaces global declaration done in bootstrap.js
+    global.Cu = mockComp.utils;
+    global.Ci = mockComp.interfaces;
+    global.Services = new MockServices();
+
+    let {Api, ContentScriptsApi} = require("content/web-extension-fake-api/models/api");
+    runtime = Api.browser.runtime;
+  });
+
+  describe("getURL(path)", function() {
+    it("dummy", function() {
+      //assert.strictEqual(runtime.getURL("hey"), "hey");
     });
+  });
+
+  after(function() {
+    global.Cu = null;
+    global.Ci = null;
+    global.Services = null;
   });
 });

--- a/tests/unit/test-webextension-fake-api.js
+++ b/tests/unit/test-webextension-fake-api.js
@@ -37,9 +37,109 @@ describe("Api.browser.runtime", function() {
   });
 
   describe("getURL(path)", function() {
-    it("dummy", function() {
-      //assert.strictEqual(runtime.getURL("hey"), "hey");
+
+    it("Mapping into about:requestpolicy nominal case", function() {
+      let path = "content/settings/pref.html";
+      let expected = "about:requestpolicy?pref"
+      assert.strictEqual(runtime.getURL(path), expected);
     });
+
+    it("Should map into about:requestpolicy if relative path doesn't start with /", function() {
+      let path = "content/settings/prefs.html";
+      let expected = "about:requestpolicy?prefs"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into about:requestpolicy if relative path starts with ./", function() {
+      let path = "./content/settings/prefs.html";
+      let expected = "about:requestpolicy?prefs"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into about:requestpolicy if mix-cased extension", function() {
+      let path = "./content/settings/extmixcase.HtMl";
+      let expected = "about:requestpolicy?extmixcase"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into about:requestpolicy if upper-cased extension", function() {
+      let path = "./content/settings/extupcase.HTML";
+      let expected = "about:requestpolicy?extupcase"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into about:requestpolicy if double extension", function() {
+      let path = "/content/settings/doubleext.html.html";
+      let expected = "about:requestpolicy?doubleext.html"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into about:requestpolicy if special chars in filename", function() {
+      let path = "/content/settings/.sp3c1@l-_[char].html";
+      let expected = "about:requestpolicy?.sp3c1@l-_[char]"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into about:requestpolicy if mix-cased filename", function() {
+      let path = "/content/settings/CaSe.html";
+      let expected = "about:requestpolicy?CaSe"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into chrome://rpcontinued/ if subdir name contains .html", function() {
+      let path = "/content/settings/subdir.html/foo.css";
+      let expected = "chrome://rpcontinued/content/settings/subdir.html/foo.css"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into chrome://rpcontinued/ if other extension than html", function() {
+      let path = "/content/settings/otherext.css";
+      let expected = "chrome://rpcontinued/content/settings/otherext.css"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into chrome://rpcontinued/ if upper-cased path", function() {
+      let path = "/CONTENT/SETTINGS/prefs.html";
+      let expected = "chrome://rpcontinued/CONTENT/SETTINGS/prefs.html"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Should map into chrome://rpcontinued/ if other path but html extension", function() {
+      let path = "/content/foo/otherpath.html";
+      let expected = "chrome://rpcontinued/content/foo/otherpath.html"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Mapping into chrome://rpcontinued/ with file in root dir", function() {
+      let path = "/root.ext";
+      let expected = "chrome://rpcontinued/root.ext"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Mapping into chrome://rpcontinued/ with file without extension", function() {
+      let path = "/noext";
+      let expected = "chrome://rpcontinued/noext"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Mapping into chrome://rpcontinued/ with a long path", function() {
+      let path = "/a/quite/very/depth/and/long/path/foo.bar";
+      let expected = "chrome://rpcontinued/a/quite/very/depth/and/long/path/foo.bar"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Mapping into chrome://rpcontinued/ with relative path not starting with /", function() {
+      let path = "content/settings/otherext.css";
+      let expected = "chrome://rpcontinued/content/settings/otherext.css"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
+    it("Mapping into chrome://rpcontinued/ with relative path starting with ./", function() {
+      let path = "./content/settings/otherext.css";
+      let expected = "chrome://rpcontinued/content/settings/otherext.css"
+      assert.strictEqual(runtime.getURL(path), expected);
+    });
+
   });
 
   after(function() {


### PR DESCRIPTION
Implements Api.browser.runtime.getURL() and adds corresponding unit tests.

**Be aware that currently:**
* `getUrl("/content/foo/bar.css")` is mapped into `chrome://rpcontinued/content/foo/bar.css` and not `chrome://rpcontinued/foo/bar.css` (see [this comment](https://github.com/RequestPolicyContinued/requestpolicy/issues/865#issuecomment-346616643))
* Matching for /content/settings is case sensitive (see [this test case](https://github.com/jrrdev/requestpolicy/blob/72bf386205b4f340ca9400b94f1256a558fbebbc/tests/unit/test-webextension-fake-api.js#L101-L105))
* Leading / and ./ are ignored (`/content/foo`is the same as `content/foo`, see [this](https://github.com/jrrdev/requestpolicy/blob/72bf386205b4f340ca9400b94f1256a558fbebbc/tests/unit/test-webextension-fake-api.js#L47-L57) and [this](https://github.com/jrrdev/requestpolicy/blob/72bf386205b4f340ca9400b94f1256a558fbebbc/tests/unit/test-webextension-fake-api.js#L131-L141))
* HTML files in a subdir of /content/settings are mapped to chrome:// (see [this](https://github.com/jrrdev/requestpolicy/blob/72bf386205b4f340ca9400b94f1256a558fbebbc/tests/unit/test-webextension-fake-api.js#L89-L93))

If any of this specs is incorrect, please tell me and I will correct it :-)