### PR TITLE
Replace pep8 by pycodestyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ TSC            := $(abspath $(node_modules_dir))/.bin/tsc
 TSLINT         := $(abspath $(node_modules_dir))/.bin/tslint
 
 # python
-PY_PEP8        := $(abspath $(python_env_dir))/bin/pep8
+PY_PYCODESTYLE := $(abspath $(python_env_dir))/bin/pycodestyle
 PY_MOZPROFILE  := $(abspath $(python_env_dir))/bin/mozprofile
 PY_MOZRUNNER   := $(abspath $(python_env_dir))/bin/mozrunner
 
@@ -447,11 +447,11 @@ lint: lint-coffee lint-js lint-python lint-ts lint-xpi
 .PHONY: lint-coffee lint-js lint-python lint-ts lint-xpi
 lint-coffee: coffeelint
 lint-js: eslint
-lint-python: pep8
+lint-python: pycodestyle
 lint-ts: ts tslint
 lint-xpi: addons-linter
 
-.PHONY: addons-linter coffeelint eslint pep8 ts tslint
+.PHONY: addons-linter coffeelint eslint pycodestyle ts tslint
 addons-linter: nightly-xpi node-packages
 	@echo $@
 	@$(ADDONS_LINTER) $(xpi_file__nightly)
@@ -465,10 +465,10 @@ eslint: node-packages
 	@$(ESLINT) tests/xpcshell/
 	@$(ESLINT) tests/helper-addons/
 	@$(ESLINT) gulpfile.js
-pep8: python-packages
+pycodestyle: python-packages
 	@echo $@
-	@$(PY_PEP8) scripts/
-	@$(PY_PEP8) tests/marionette/
+	@$(PY_PYCODESTYLE) scripts/
+	@$(PY_PYCODESTYLE) tests/marionette/
 ts: node-packages
 	@echo $@
 	@$(TSC)

--- a/dev_env/python-requirements.txt
+++ b/dev_env/python-requirements.txt
@@ -1,4 +1,4 @@
-pep8
+pycodestyle
 
 firefox-puppeteer == 50
 firefox-ui-harness == 1.3

--- a/scripts/check_gecko_log.py
+++ b/scripts/check_gecko_log.py
@@ -26,5 +26,6 @@ def main():
                 print line
         exit(code=1)
 
+
 if __name__ == "__main__":
     main()

--- a/tests/marionette/rp_puppeteer/tests/test_menu.py
+++ b/tests/marionette/rp_puppeteer/tests/test_menu.py
@@ -32,7 +32,7 @@ class MenuTests:
                 else:
                     self.menu.close()
                 self.assertFalse(self.menu.is_open())
-            except:
+            except:  # noqa
                 print "trigger: " + self.trigger
                 raise
 

--- a/tests/marionette/rp_ui_harness/runtests.py
+++ b/tests/marionette/rp_ui_harness/runtests.py
@@ -59,5 +59,6 @@ def cli(args=None):
            args=args
            )
 
+
 if __name__ == '__main__':
     cli()

--- a/tests/marionette/rp_ui_harness/utils/redirections.py
+++ b/tests/marionette/rp_ui_harness/utils/redirections.py
@@ -166,7 +166,7 @@ def for_each_possible_redirection_scenario(callback, uri_type):
     def callback_wrapper(uris, info):
         try:
             callback(uris, info=info)
-        except:
+        except:  # noqa
             print "info: " + str(info)
             print "uris: " + str(uris)
             raise

--- a/tests/marionette/tests-quick/settings/test_checkboxes.py
+++ b/tests/marionette/tests-quick/settings/test_checkboxes.py
@@ -125,7 +125,7 @@ class TestCheckboxes(RequestPolicyTestCase):
                 self.assertEqual(cb_value, pref_value)
             else:
                 self.assertNotEqual(cb_value, pref_value)
-        except:
+        except:  # noqa
             print ("pref name: {}, checkbox: {}, pref: {}"
                    .format(pref["name"], str(cb_value), str(pref_value)))
             raise

--- a/tests/marionette/tests/redirections/test_link_click_redirect_in_new_tab.py
+++ b/tests/marionette/tests/redirections/test_link_click_redirect_in_new_tab.py
@@ -155,7 +155,7 @@ class TestLinkClickRedirectInNewTab(RequestPolicyTestCase):
             try:
                 redirections.for_each_possible_redirection_scenario(maybe_test,
                                                                     "link")
-            except:
+            except:  # noqa
                 print "test variant: " + str(args[0])
                 raise
 


### PR DESCRIPTION
# Issue description
* When launching `make lint`, the following message appears:
```bash
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.
```
* Python linter doesn't seems to be executed or lint errors are not shown ?

# Changelog
* Use package pycodestyle instead of pep8
* Rename make target to pycodestyle instead of pep8
* Fix lint